### PR TITLE
 Lack of flags for vanity generation

### DIFF
--- a/cmd/nem/main.go
+++ b/cmd/nem/main.go
@@ -90,7 +90,7 @@ func vanityAction(c *cli.Context) error {
 
 	var pr string
 	var prefixes []string
-	switch c.Args() {
+	switch len(c.Args()) {
 	case 0:
 		return cli.NewExitError("wrong args - prefix is not specified", 1)
 	case 1:

--- a/cmd/nem/main.go
+++ b/cmd/nem/main.go
@@ -90,7 +90,7 @@ func vanityAction(c *cli.Context) error {
 
 	var pr string
 	var prefixes []string
-	switch len(c.Args()) {
+	switch c.Args() {
 	case 0:
 		return cli.NewExitError("wrong args - prefix is not specified", 1)
 	case 1:
@@ -104,14 +104,14 @@ func vanityAction(c *cli.Context) error {
 			if !vanity.IsPrefixCorrect(pr) {
 				return cli.NewExitError("wrong args - invalid prefix format", 1)
 			}
-			pr = prependPrefix(ch, pr)
-			prefixes = append(prefixes, pr)
+			prefixes = append(prefixes, prependPrefix(ch, pr))
 		}
 	}
 
 	rs := make(chan keypair.KeyPair)
 	for i := 0; i < runtime.NumCPU(); i++ {
 		predicates := make([]vanity.Predicate, 0)
+
 		if len(prefixes) != 0 {
 			predicates = append(predicates, vanity.MultPrefixPredicate{
 				Prefixes: prefixes,

--- a/cmd/nem/main.go
+++ b/cmd/nem/main.go
@@ -58,6 +58,19 @@ func main() {
 					Name:   "vanity",
 					Usage:  "Find vanity address by given prefix",
 					Action: vanityAction,
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:   "no-digits",
+							EnvVar: "NEM_NO_DIGIT",
+							Usage:  "disallow digits in account",
+						},
+						cli.StringSliceFlag{
+							Name:   "any-pos",
+							Value:  nil,
+							EnvVar: "NEM_ANY_POS",
+							Usage:  "list of prefixes for vanity search",
+						},
+					},
 				},
 			},
 		},
@@ -80,10 +93,71 @@ func vanityAction(c *cli.Context) error {
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
-	if len(c.Args()) != 1 {
+
+	var pr string
+	var prefixes []string
+	switch len(c.Args()) {
+	case 0:
 		return cli.NewExitError("wrong args - prefix is not specified", 1)
+	case 1:
+		pr := strings.ToUpper(c.Args().First())
+		if !vanity.IsPrefixCorrect(pr) {
+			return cli.NewExitError("wrong args - invalid prefix format", 1)
+		}
+		pr = prependPrefix(ch, pr)
+
+	default:
+		for _, pr := range c.GlobalStringSlice("any-pos") {
+			if !vanity.IsPrefixCorrect(pr) {
+				return cli.NewExitError("wrong args - invalid prefix format", 1)
+			}
+			pr = prependPrefix(ch, pr)
+			prefixes = append(prefixes, pr)
+		}
 	}
-	pr := strings.ToUpper(c.Args().First())
+
+	rs := make(chan keypair.KeyPair)
+	for i := 0; i < runtime.NumCPU(); i++ {
+		predicates := make([]vanity.Predicate, 0)
+		addr_ch := make(chan keypair.Address, 1)
+
+		if len(prefixes) != 0 {
+			predicates = append(predicates, vanity.Predicate{
+				F: func() bool {
+					addr := <-addr_ch
+					vanity.CheckMultPrefix(addr, prefixes)
+					return true
+				},
+				Addr_ch: addr_ch,
+			})
+		} else {
+			predicates = append(predicates, vanity.Predicate{
+				F: func() bool {
+					addr := <-addr_ch
+					vanity.CheckPrefix(addr, pr)
+					return true
+				},
+				Addr_ch: addr_ch,
+			})
+		}
+
+		if c.GlobalBool("no-digits") {
+			predicates = append(predicates, vanity.Predicate{
+				F: func() bool {
+					addr := <-addr_ch
+					return vanity.CheckNoDigits(addr)
+				},
+				Addr_ch: addr_ch,
+			})
+		}
+
+		go vanity.Search(ch, rs, predicates)
+	}
+	printAccountDetails(ch, <-rs)
+	return nil
+}
+
+func prependPrefix(ch core.Chain, pr string) string {
 	switch ch {
 	case core.Mijin:
 		pr = "M" + pr
@@ -92,12 +166,7 @@ func vanityAction(c *cli.Context) error {
 	case core.Testnet:
 		pr = "T" + pr
 	}
-	rs := make(chan keypair.KeyPair)
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go vanity.FindByPrefix(ch, pr, rs)
-	}
-	printAccountDetails(ch, <-rs)
-	return nil
+	return pr
 }
 
 func chainGlobalOption(c *cli.Context) (core.Chain, error) {

--- a/pkg/vanity/vanity.go
+++ b/pkg/vanity/vanity.go
@@ -17,12 +17,15 @@ type Predicate interface {
 	call(addr keypair.Address) bool
 }
 
+// NoDigitPredicate checks account for absence of digits
 type NoDigitPredicate struct{}
 
+// PrefixPredicate checks account for selected prefix
 type PrefixPredicate struct {
 	Prefix string
 }
 
+// MultPrefixPredicate checks account for any of specified prefixes
 type MultPrefixPredicate struct {
 	Prefixes []string
 }
@@ -62,11 +65,12 @@ func Search(chain core.Chain, ch chan<- keypair.KeyPair, predicates []Predicate)
 	}
 }
 
-// CheckPrefix checks if address satisfies prefix
+
 func checkPrefix(addr keypair.Address, prefix string) bool {
 	return strings.HasPrefix(addr.String(), prefix)
 }
 
+// IsPrefixCorrect verify that prefix can be used
 func IsPrefixCorrect(prefix string) bool {
 	return regexp.MustCompile("^[A-D][A-Z2-7]*$").MatchString(prefix)
 }

--- a/pkg/vanity/vanity.go
+++ b/pkg/vanity/vanity.go
@@ -65,7 +65,6 @@ func Search(chain core.Chain, ch chan<- keypair.KeyPair, predicates []Predicate)
 	}
 }
 
-
 func checkPrefix(addr keypair.Address, prefix string) bool {
 	return strings.HasPrefix(addr.String(), prefix)
 }

--- a/pkg/vanity/vanity_test.go
+++ b/pkg/vanity/vanity_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestIsPrefixCorrect(t *testing.T) {
-	assert.True(t, IsPrefixCorrect("-A"))
-	assert.True(t, IsPrefixCorrect("-AB"))
-	assert.True(t, IsPrefixCorrect("_D234"))
+	assert.True(t, IsPrefixCorrect("A"))
+	assert.True(t, IsPrefixCorrect("AB"))
+	assert.True(t, IsPrefixCorrect("D234"))
 
 	assert.False(t, IsPrefixCorrect("_A123"))
 	assert.False(t, IsPrefixCorrect("_ABC_"))

--- a/pkg/vanity/vanity_test.go
+++ b/pkg/vanity/vanity_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestIsPrefixCorrect(t *testing.T) {
-	assert.True(t, isPrefixCorrect("-A"))
-	assert.True(t, isPrefixCorrect("-AB"))
-	assert.True(t, isPrefixCorrect("_D234"))
+	assert.True(t, IsPrefixCorrect("-A"))
+	assert.True(t, IsPrefixCorrect("-AB"))
+	assert.True(t, IsPrefixCorrect("_D234"))
 
-	assert.False(t, isPrefixCorrect("_A123"))
-	assert.False(t, isPrefixCorrect("_ABC_"))
-	assert.False(t, isPrefixCorrect("_XABC"))
+	assert.False(t, IsPrefixCorrect("_A123"))
+	assert.False(t, IsPrefixCorrect("_ABC_"))
+	assert.False(t, IsPrefixCorrect("_XABC"))
 }


### PR DESCRIPTION
Added flag for no-digits search (`--no-digits`).
Upgraded prefix search
user can specify single/multiple prefixes without flags:
`nem --chain mainnet  account vanity DONAT`
`nem --chain mainnet  account vanity DONAT DONER`

Fix #59.